### PR TITLE
Resolve semantic issue warning

### DIFF
--- a/BVLinearGradient.m
+++ b/BVLinearGradient.m
@@ -19,7 +19,7 @@
 {
   NSMutableArray *colors = [NSMutableArray arrayWithCapacity:colorStrings.count];
   for (NSString *colorString in colorStrings) {
-    [colors addObject:[RCTConvert UIColor:colorString].CGColor];
+    [colors addObject:(id)[RCTConvert UIColor:colorString].CGColor];
   }
   self.gradientLayer.colors = colors;
 }


### PR DESCRIPTION
This should resolve the semantic issue warning i get for that line:
```
BVLinearGradient.m:22:24: Incompatible pointer types sending 'CGColorRef' (aka 'struct CGColor *') to parameter of type 'id'
```