### PR TITLE
[iOS] Fix "null is not an object (evaluating 'prevComponentInstance._…

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -6,14 +6,14 @@
 'use strict';
 
 var React = require('react-native');
-var { requireNativeComponent, processColor } = React;
+var { requireNativeComponent } = React;
 var NativeLinearGradient = requireNativeComponent('BVLinearGradient', null);
 
 var LinearGradient = React.createClass({
   render: function() {
     var { colors, ...otherProps } = this.props;
     return (
-      <NativeLinearGradient {...otherProps} colors={colors.map(processColor)} />
+      <NativeLinearGradient {...otherProps} colors={colors} />
     );
   }
 });


### PR DESCRIPTION
…currentElement')

As seen [here](https://github.com/brentvatne/react-native-linear-gradient/blob/master/BVLinearGradient.m#L22) the native linear gradient component expects an array of color strings to be set as its colors property. However an array of color integers were being sent, which was causing the error in the title whenever the LinearGradient component was used.