### PR TITLE
Add missing prop types for native props in Android

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -7,7 +7,12 @@ var LinearGradient = React.createClass({
     start: PropTypes.array,
     end: PropTypes.array,
     colors: PropTypes.array.isRequired,
-    locations: PropTypes.array
+    locations: PropTypes.array,
+    scaleX: PropTypes.number,
+    scaleY: PropTypes.number,
+    translateX: PropTypes.number,
+    translateY: PropTypes.number,
+    rotation: PropTypes.number
   },
 
   render: function() {


### PR DESCRIPTION
Fixes this issue:
![screenshot 2015-10-26 17 36 42](https://cloud.githubusercontent.com/assets/882152/10725600/268ca334-7c08-11e5-9268-bfe69e184ac3.png)

Using react-native 0.13.1