### PR TITLE
Add "main" entry point to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-linear-gradient",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A <LinearGradient> element for react-native",
   "main": "index.ios.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-native-linear-gradient",
   "version": "1.3.0",
   "description": "A <LinearGradient> element for react-native",
+  "main": "index.ios.js",
   "author": {
     "name": "Brent Vatne",
     "email": "brentvatne@gmail.com",


### PR DESCRIPTION
When it's missing Flow complains. I picked ios version because it already has `@flow` in it and both iOS and Android export a React component.