### PR TITLE
Fix package entry point and default end position value on Android

### DIFF
--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
@@ -29,14 +29,14 @@ public class LinearGradientView extends View {
 
         ReadableArray colors = props.getArray("colors");
 
-        //If we managed to get here and not get colors... give up.
+        // if we managed to get here and not get colors, give up.
         assert colors != null;
+
         mColors = new int[colors.size()];
         for (int i=0; i < mColors.length; i++)
         {
             mColors[i] = colors.getInt(i);
         }
-
 
         try {
             ReadableArray locations = props.getArray("locations");
@@ -58,13 +58,12 @@ public class LinearGradientView extends View {
           mStartPos = new float[]{0,0};
         }
 
-
         try {
             ReadableArray endPos = props.getArray("end");
             assert endPos != null;
             mEndPos= new float[]{(float) endPos.getDouble(0), (float) endPos.getDouble(1)};
         } catch (Exception e) {
-          //default to full height.
+            // default to full height.
             mEndPos = new float[]{0, 1};
         }
         mSize = new int[]{0, 0};

--- a/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
+++ b/android/src/main/java/com/BV/LinearGradient/LinearGradientView.java
@@ -65,7 +65,7 @@ public class LinearGradientView extends View {
             mEndPos= new float[]{(float) endPos.getDouble(0), (float) endPos.getDouble(1)};
         } catch (Exception e) {
           //default to full height.
-            mEndPos = new float[]{0, getMeasuredHeight()};
+            mEndPos = new float[]{0, 1};
         }
         mSize = new int[]{0, 0};
         drawGradient();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-linear-gradient",
   "version": "1.3.1",
   "description": "A <LinearGradient> element for react-native",
-  "main": "index.ios.js",
+  "main": "index",
   "author": {
     "name": "Brent Vatne",
     "email": "brentvatne@gmail.com",


### PR DESCRIPTION
Closes #52 

Technically, only 0fd376a004c209479a67499a08f2e9ee7912811f is needed to close #52. b63f00ab0bf77b275703c9eef3664ecafc30f502 is another Android problem I've found while working on this issue. Let me know if I should open a separate pull request for it.