### PR TITLE
Work on Android even if style is not passed in

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -16,7 +16,7 @@ var LinearGradient = React.createClass({
 
     // inherit container borderRadius until this issue is resolved:
     // https://github.com/facebook/react-native/issues/3198
-    var borderRadius = flattenStyle(style).borderRadius || 0;
+    var borderRadius = style && flattenStyle(style).borderRadius || 0;
 
     return (
       <View {...otherProps} style={style}>


### PR DESCRIPTION
Otherwise we get a "Cannot read property 'borderRadius' of undefined" since [flattenStyle() will return undefined](https://github.com/facebook/react-native/blob/62e8ddc20561a39c3c839ab9f83c95493df117c0/Libraries/StyleSheet/flattenStyle.js#L28) if style is undefined.