### PR TITLE
Possible Fix for #62 & error with React-Native 0.22.0+

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,5 +1,5 @@
 var React = require('react-native');
-var flattenStyle = require('flattenStyle');
+var flattenStyle = React.StyleSheet.flatten;
 var { requireNativeComponent, processColor, PropTypes, View } = React;
 
 var LinearGradient = React.createClass({


### PR DESCRIPTION
With the new React-Native build (0.22.0+), this fixes the error:

`Requiring unknown module "flattenStyle"`