### PR TITLE
Add required fields to podspec

### DIFF
--- a/BVLinearGradient.podspec
+++ b/BVLinearGradient.podspec
@@ -3,6 +3,8 @@ Pod::Spec.new do |s|
   s.name         = "BVLinearGradient"
   s.version      = "1.5.2"
   s.homepage     = "https://github.com/brentvatne/react-native-linear-gradient"
+  s.summary      = "A <LinearGradient /> component for react-native"
+  s.author       = "Brent Vatne"
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/brentvatne/react-native-linear-gradient.git", :tag => "#{s.version}" }
   s.source_files = 'BVLinearGradient/*.{h,m}'


### PR DESCRIPTION
Cocoapods >= 1 requires `summary` and `author`