### PR TITLE
Separate React from ReactNative

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,6 +1,8 @@
-var React = require('react-native');
-var flattenStyle = React.StyleSheet.flatten;
-var { requireNativeComponent, processColor, PropTypes, View } = React;
+var React = require('react');
+var { PropTypes } = React;
+var ReactNative = require('react-native');
+var flattenStyle = ReactNative.StyleSheet.flatten;
+var { requireNativeComponent, processColor, View } = React;
 
 var LinearGradient = React.createClass({
   propTypes: {

--- a/index.ios.js
+++ b/index.ios.js
@@ -5,8 +5,9 @@
 
 'use strict';
 
-var React = require('react-native');
-var { requireNativeComponent, processColor, PropTypes, View } = React;
+var React = require('react');
+var { PropTypes } = React;
+var { requireNativeComponent, processColor, View } = require('react-native');
 
 var LinearGradient = React.createClass({
   propTypes: {


### PR DESCRIPTION
In React Native 0.25, React Native stops wrapping shared React functionality (createClass, PropTypes etc. -- see https://github.com/facebook/react-native/commit/2eafcd45dbd42f750df1ab9aa3770fed5cdf11ae) and expects end users to import these from the react package instead. This PR implements that behavior.
