### PR TITLE
CocoaPods 1.0 support.

### DIFF
--- a/BVLinearGradient.podspec
+++ b/BVLinearGradient.podspec
@@ -1,14 +1,19 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
 Pod::Spec.new do |s|
 
-  s.name         = "BVLinearGradient"
-  s.version      = "1.5.6"
-  s.homepage     = "https://github.com/brentvatne/react-native-linear-gradient"
-  s.summary      = "A <LinearGradient /> component for react-native"
-  s.author       = "Brent Vatne"
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/brentvatne/react-native-linear-gradient.git", :tag => "#{s.version}" }
-  s.source_files = 'BVLinearGradient/*.{h,m}'
-  s.preserve_paths = "**/*.js"
+  s.name            = "BVLinearGradient"
+  s.version         = version
+  s.homepage        = "https://github.com/brentvatne/react-native-linear-gradient"
+  s.summary         = "A <LinearGradient /> component for react-native"
+  s.license         = "MIT"
+  s.author          = { "Brent Vatne" => "brentvatne@gmail.com" }
+  s.platform        = :ios, "7.0"
+  s.source          = { :git => "https://github.com/brentvatne/react-native-linear-gradient.git", :tag => "#{s.version}" }
+  s.source_files    = 'BVLinearGradient/*.{h,m}'
+  s.preserve_paths  = "**/*.js"
+  
   s.dependency 'React'
 
 end


### PR DESCRIPTION
CocoaPods 1.0 was recently released and introduces some changes to podspec requirements. This PR addresses those and makes the version to be based on `package.json` so there's less work to do releases. 