### PR TITLE
optional style property

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -19,7 +19,7 @@ var LinearGradient = React.createClass({
 
     // inherit container borderRadius until this issue is resolved:
     // https://github.com/facebook/react-native/issues/3198
-    var flatStyle = style && StyleSheet.flatten(style);
+    var flatStyle = style && StyleSheet.flatten(style) || {};
     var borderRadius = flatStyle.borderRadius || 0;
 
     // this is the format taken by:


### PR DESCRIPTION
If `style` prop is not passed to the component, it will fail when trying to access properties of `undefined` object. I suppose `style` prop shouldn't be required.